### PR TITLE
fixed height causes flicker

### DIFF
--- a/res/css/jd.gallery.css
+++ b/res/css/jd.gallery.css
@@ -17,7 +17,6 @@
 
 .jdGallery .slideElement {
 	background-size: contain;
-	/*background-size: cover;*/
 }
 
 #flickrGallery

--- a/res/css/jd.gallery.css
+++ b/res/css/jd.gallery.css
@@ -148,7 +148,7 @@
 {
 	position: absolute;
 	width: 100%;
-	height: 78px;
+	/*height: 78px;*/
 	top: 10px;
 	left: 0;
 	overflow: hidden;

--- a/res/css/jd.gallery.css
+++ b/res/css/jd.gallery.css
@@ -1,5 +1,5 @@
 .tx-rgsmoothgallery-pi1 {
-    background:#000 url(img/loading-bar-black.gif) center center no-repeat;
+	background:#000 url(img/loading-bar-black.gif) center center no-repeat;
 	width:100% !important;
 }
 #myGallery, #myGallerySet, #flickrGallery

--- a/res/css/jd.gallery.css
+++ b/res/css/jd.gallery.css
@@ -154,7 +154,6 @@
 {
 	position: absolute;
 	width: 100%;
-	/*height: 78px;*/
 	top: 10px;
 	left: 0;
 	overflow: hidden;

--- a/res/css/jd.gallery.css
+++ b/res/css/jd.gallery.css
@@ -1,5 +1,6 @@
 .tx-rgsmoothgallery-pi1 {
     background:#000 url(img/loading-bar-black.gif) center center no-repeat;
+	width:100% !important;
 }
 #myGallery, #myGallerySet, #flickrGallery
 {
@@ -12,6 +13,11 @@
 .jdGallery a
 {
 	outline:0;
+}
+
+.jdGallery .slideElement {
+	background-size: contain;
+	/*background-size: cover;*/
 }
 
 #flickrGallery
@@ -29,6 +35,7 @@
 {
 	overflow: hidden;
 	position: relative;
+	width:100% !important;
 }
 
 .jdGallery img


### PR DESCRIPTION
In Chrome on a Typo3 website (with jQuery using noConflict()) the thumbnails flicker when I hover over them. This can be fixed by removing the one line with the height value (it seems there is something recalculated or moved when this is in the CSS).

We should add some option to enable responsive behavior. You can take my changes as starting point.
